### PR TITLE
Remove reliance on Blender initial names 

### DIFF
--- a/microscopynodes/blender_manifest.toml
+++ b/microscopynodes/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "microscopynodes"
-version = "1.1.3"
+version = "1.1.4"
 name = "Microscopy Nodes"
 tagline = "Handling microscopy data in Blender, up to 5D volumes"
 maintainer = "Oane Gros <oane.gros@embl.de>"

--- a/microscopynodes/handle_blender_structs/collection_handling.py
+++ b/microscopynodes/handle_blender_structs/collection_handling.py
@@ -1,6 +1,6 @@
 import bpy
 
-def get_collection(name, supercollections=[], duplicate=False, under_active_coll=False):
+def get_collection(name, supercollections=['Microscopy Nodes'], duplicate=False, under_active_coll=False):
     # duplicate is not duplicated-name-safe, so intention is to have types of names with/without duplication (programmer's choice)
     coll = bpy.context.scene.collection
     lcoll = bpy.context.view_layer.layer_collection
@@ -18,7 +18,7 @@ def get_collection(name, supercollections=[], duplicate=False, under_active_coll
     lcoll = lcoll.children[name]
     return newcoll, lcoll
 
-def collection_by_name(name, supercollections=[], duplicate=False):
+def collection_by_name(name, supercollections=['Microscopy Nodes'], duplicate=False):
     coll, lcoll = get_collection(name, supercollections, duplicate, under_active_coll=False)
     collection_activate(coll, lcoll)
     return coll, lcoll

--- a/microscopynodes/handle_blender_structs/collection_handling.py
+++ b/microscopynodes/handle_blender_structs/collection_handling.py
@@ -1,6 +1,6 @@
 import bpy
 
-def get_collection(name, supercollections=['Microscopy Nodes'], duplicate=False, under_active_coll=False):
+def get_collection(name, supercollections=[], duplicate=False, under_active_coll=False):
     # duplicate is not duplicated-name-safe, so intention is to have types of names with/without duplication (programmer's choice)
     coll = bpy.context.scene.collection
     lcoll = bpy.context.view_layer.layer_collection
@@ -18,7 +18,7 @@ def get_collection(name, supercollections=['Microscopy Nodes'], duplicate=False,
     lcoll = lcoll.children[name]
     return newcoll, lcoll
 
-def collection_by_name(name, supercollections=['Microscopy Nodes'], duplicate=False):
+def collection_by_name(name, supercollections=[], duplicate=False):
     coll, lcoll = get_collection(name, supercollections, duplicate, under_active_coll=False)
     collection_activate(coll, lcoll)
     return coll, lcoll

--- a/microscopynodes/initial_global_settings.py
+++ b/microscopynodes/initial_global_settings.py
@@ -15,7 +15,7 @@ def preset_environment():
     bpy.context.scene.cycles.use_denoising = False # this will introduce noise, but at least also not remove data-noise
 
     try:
-        bpy.data.worlds["World"].node_tree.nodes["Background"].inputs[0].default_value = (0.5, 0.5, 0.5, 1)
+        bpy.context.scene.world.node_tree.nodes["Background"].inputs[0].default_value = (0.5, 0.5, 0.5, 1)
     except:
         pass
 
@@ -23,7 +23,7 @@ def preset_environment():
 
 def preset_em_environment():
     try:
-        bpy.data.worlds["World"].node_tree.nodes["Background"].inputs[0].default_value = (1, 1, 1, 1)
+        bpy.context.scene.world.node_tree.nodes["Background"].inputs[0].default_value = (1, 1, 1, 1)
     except:
         pass
     return

--- a/microscopynodes/load.py
+++ b/microscopynodes/load.py
@@ -96,9 +96,9 @@ def load():
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     
-    base_coll = collection_by_name('Collection')
+    base_coll = collection_by_name('Microscopy Nodes', supercollections=[])
     collection_activate(*base_coll)
-    collection_by_name('cache')
+    collection_by_name('cache',supercollections=[])
     cache_coll = collection_by_name(Path(input_file).stem, supercollections=['cache'], duplicate=True)
     
     # pads axes order with 1-size elements for missing axes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microscopynodes"
-version = "1.1.3"
+version = "1.1.4"
 description = "Loading and handling microscopy data in Blender."
 authors = ["Oane Gros <oane.gros@embl.de>"]
 include = [


### PR DESCRIPTION
Remove reliance on 'World' name for presetting env, move all MiN objects to new collection `Microscopy Nodes` to not prefer a 'Collection' instance being present so that this does not accidentally becomes essential